### PR TITLE
Only able to use apache2-prefork-dev to compile passenger

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,3 +2,4 @@ default[:passenger][:version]     = "3.0.11"
 default[:passenger][:max_pool_size] = "6"
 default[:passenger][:root_path]   = "#{languages[:ruby][:gems_dir]}/gems/passenger-#{passenger[:version]}"
 default[:passenger][:module_path] = "#{passenger[:root_path]}/ext/apache2/mod_passenger.so"
+default[:passenger][:apache_mpm]  = 'prefork'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -38,7 +38,12 @@ when "centos","redhat"
     package 'zlib-devel'
   end
 else
-  %w{ apache2-prefork-dev libapr1-dev libcurl4-gnutls-dev }.each do |pkg|
+  apache_development_package =  if %w( worker threaded ).include? node['passenger']['apache_mpm']
+                                  'apache2-threaded-dev'
+                                else
+                                  'apache2-prefork-dev'
+                                end
+  %W( #{apache_development_package} libapr1-dev libcurl4-gnutls-dev ).each do |pkg|
     package pkg do
       action :upgrade
     end


### PR DESCRIPTION
Allow the option to choose which mpm method to compile passenger against. See http://tickets.opscode.com/browse/COOK-2003
