### PR TITLE
Don't install passenger on each run

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -57,4 +57,5 @@ end
 execute "passenger_module" do
   command 'passenger-install-apache2-module --auto'
   creates node[:passenger][:module_path]
+  not_if { `passenger --version` =~ /#{Regexp.escape(node['passenger']['version'])}/ }
 end


### PR DESCRIPTION
This PR checks for the passenger version (by running the `--version` command) against the attribute-specified version.

Favored over #6.

Ticket: http://tickets.opscode.com/browse/COOK-2068
