### PR TITLE
[COOK-2293] reload attributes

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -44,5 +44,5 @@ ruby_block "reload_ruby" do
   end
 
   action :nothing
-  subscribes :create, resources("ohai[reload]"), :immediately
+  subscribes :create, "ohai[reload]", :immediately
 end


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-2293

If a user of this cookbook also installs ruby, then when chef-client is first run on the node the Ohai attribute `languages[:ruby][:gems_dir]` points to the embedded version of ruby.

This pull request adds a block that reloads the attributes for this cookbook whenever Ohai's reload action is run. In this way, if ruby is installed from another cookbook that cookbook need only tell Ohai to reload its attributes and the passenger_apache2 cookbook will in turn update its attributes.

My company has signed the CLA; I'm currently waiting on someone from OpsCode to add me to the contributor list. Will update when that's done.
