### PR TITLE
[COOK-2750] enable passenger apache module in mod_rails recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,7 +36,3 @@ end
 if(node['passenger']['manage_module_conf'])
   include_recipe 'passenger_apache2::mod_rails'
 end
-
-apache_module 'passenger' do
-  module_path node['passenger']['module_path']
-end

--- a/recipes/mod_rails.rb
+++ b/recipes/mod_rails.rb
@@ -44,3 +44,7 @@ template "#{node['apache']['dir']}/mods-available/passenger.conf" do
   group 'root'
   mode 0644
 end
+
+apache_module 'passenger' do
+  module_path node['passenger']['module_path']
+end


### PR DESCRIPTION
Some users just put mod_rails recipe in their run_list instead of
the default recipe since that worked prior to the 2.0 release of
this cookbook.
This ensures the passenger apache module files are created before
attempting to enable the module.
