### PR TITLE
Fix reliability of calling passenger-install-apache2-module

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -48,6 +48,6 @@ gem_package "passenger" do
 end
 
 execute "passenger_module" do
-  command "#{languages['ruby']['bin_dir']}/passenger-install-apache2-module --auto"
+  command "#{node['languages']['ruby']['bin_dir']}/passenger-install-apache2-module --auto"
   creates node['passenger']['module_path']
 end


### PR DESCRIPTION
...ctory

The ruby bin directory (especially when using alternate installation paths) is not always in the current path.  This will result in this execute failing as passenger-install-apache2-module will not be found.
