### PR TITLE
[COOK-3746] Fix variables

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -24,6 +24,11 @@
 
 include_recipe 'apache2'
 
+# Allows proper default path if root path was overridden
+passenger_module_dir_name = node['passenger']['version'].start_with?('4') ? 'buildout' : 'ext'
+node.default['passenger']['root_path']   = "#{node['languages']['ruby']['gems_dir']}/gems/passenger-#{node['passenger']['version']}"
+node.default['passenger']['module_path'] = "#{node['passenger']['root_path']}/#{passenger_module_dir_name}/apache2/mod_passenger.so"
+
 case node['passenger']['install_method']
 when 'source'
   include_recipe 'passenger_apache2::source'

--- a/recipes/mod_rails.rb
+++ b/recipes/mod_rails.rb
@@ -34,11 +34,6 @@ if platform_family?('debian')
   end
 end
 
-# Allows proper default path if root path was overridden
-passenger_module_dir_name = node['passenger']['version'].start_with?('4') ? 'buildout' : 'ext'
-node.default['passenger']['root_path']   = "#{node.languages['ruby']['gems_dir']}/gems/passenger-#{node['passenger']['version']}"
-node.default['passenger']['module_path'] = "#{node['passenger']['root_path']}/#{passenger_module_dir_name}/apache2/mod_passenger.so"
-
 template "#{node['apache']['dir']}/mods-available/passenger.conf" do
   cookbook 'passenger_apache2'
   source 'passenger.conf.erb'

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -18,6 +18,11 @@ include_recipe "build-essential"
 
 node.default['passenger']['apache_mpm']  = 'prefork'
 
+# Allows proper default path if root path was overridden
+passenger_module_dir_name = node['passenger']['version'].start_with?('4') ? 'buildout' : 'ext'
+node.default['passenger']['root_path']   = "#{node['languages']['ruby']['gems_dir']}/gems/passenger-#{node['passenger']['version']}"
+node.default['passenger']['module_path'] = "#{node['passenger']['root_path']}/#{passenger_module_dir_name}/apache2/mod_passenger.so"
+
 case node['platform_family']
 when "arch"
   package "apache"
@@ -46,11 +51,6 @@ end
 gem_package "passenger" do
   version node['passenger']['version']
 end
-
-# Allows proper default path if root path was overridden
-passenger_module_dir_name = node['passenger']['version'].start_with?('4') ? 'buildout' : 'ext'
-node.default['passenger']['root_path']   = "#{node.languages['ruby']['gems_dir']}/gems/passenger-#{node['passenger']['version']}"
-node.default['passenger']['module_path'] = "#{node['passenger']['root_path']}/#{passenger_module_dir_name}/apache2/mod_passenger.so"
 
 execute "passenger_module" do
   command "passenger-install-apache2-module _#{node['passenger']['version']}_ --auto"


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3746
### Fix `root_path` to use `version`

Since `node['passenger']['root_path']` depends on `node['passenger']['version']`, the default value should be redefined in recipe. Without it, `root_path` will use different version from `version`. I'm not sure this is the best way - and there is duplicated code :( But it fixes the problem.
### Fix passenger so path

Passenger 4.0.8 creates .so file in buildout, not ext directory. see https://github.com/FooBarWidget/passenger/commit/dcaf0ea5310e87c935dd39abd6502e00ba8b5ddd

I'm not sure from which version the output directory have been changed. There is no way to know the output directory :( passenger-config does not have option for it.
