### PR TITLE
[COOK-3747] Call full path for installing module

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -48,6 +48,6 @@ gem_package "passenger" do
 end
 
 execute "passenger_module" do
-  command "passenger-install-apache2-module _#{node['passenger']['version']}_ --auto"
+  command "#{node['languages']['ruby']['ruby_bin']} #{node['passenger']['root_path']}/bin/passenger-install-apache2-module _#{node['passenger']['version']}_ --auto"
   creates node['passenger']['module_path']
 end


### PR DESCRIPTION
See https://tickets.opscode.com/browse/COOK-3747

Same problem with #17 - but more explicit way. `passenger-install-apache2-module` binary may not be in the ruby bin directory when using rbenv.
