### PR TITLE
[COOK-3395] Make sure to compile the version of passenger on the node attrribute

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -47,7 +47,6 @@ gem_package "passenger" do
   version node['passenger']['version']
 end
 
-
 execute "passenger_module" do
   command "passenger-install-apache2-module _#{node['passenger']['version']}_ --auto"
   creates node['passenger']['module_path']


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3395

Currently, installing passenger version x via this recipe, then changing to version y where y < x leads to breakage, as version y is not compiled. 

When compiling from source, the cookbook calls _passenger-install-apache2-module_. By default this will compile the most recent version of the passenger gem on the machine. In the case that the version specified on the node is older than the most recent version installed on the node, the older version will not be compiled (the latest version will be recompiled). However the apache config will be updated as though the older version had been compiled, leading to breakage,

This change passes the node passenger version attribute to _passenger-install-apache2-module_ to force compilation of the specified version.
