### PR TITLE
[COOK-3654] don't run node.load_attribute_by_short_filename on Chef 11

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,7 +40,10 @@ end
 
 ruby_block "reload_ruby" do
   block do
-    node.load_attribute_by_short_filename('default', 'passenger_apache2')
+    # Only available on Chef 10.x, but only needed there anyway
+    if node.respond_to?(:load_attribute_by_short_filename)
+      node.load_attribute_by_short_filename('default', 'passenger_apache2')
+    end
   end
 
   action :nothing


### PR DESCRIPTION
This should fix https://tickets.opscode.com/browse/COOK-3654.
