### PR TITLE
[COOK-4081] Use passenger.ruby_bin for install command.

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -48,6 +48,6 @@ gem_package "passenger" do
 end
 
 execute "passenger_module" do
-  command "#{node['languages']['ruby']['ruby_bin']} #{node['passenger']['root_path']}/bin/passenger-install-apache2-module _#{node['passenger']['version']}_ --auto"
+  command "#{node['passenger']['ruby_bin']} #{node['passenger']['root_path']}/bin/passenger-install-apache2-module _#{node['passenger']['version']}_ --auto"
   creates node['passenger']['module_path']
 end


### PR DESCRIPTION
The passenger apache template is correctly using the passenger.ruby_bin
attribute. The installer command does not. This commit fixes the
behavior, now the template and the installer command use the same ruby.

See also: https://tickets.opscode.com/browse/COOK-4081
