### PR TITLE
Constrain apache2 cookbook version dependency to less than v2.0.0.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,7 +9,7 @@ version           "2.2.1"
 recipe "passenger_apache2", "Installs Passenger as an Apache module"
 recipe "passenger_apache2::mod_rails", "Enables Apache module configuration for passenger module"
 
-depends "apache2", ">= 1.0.4"
+depends "apache2", "~> 1.0"
 depends "build-essential"
 
 %w{ redhat centos scientific amazon oracle ubuntu debian arch }.each do |os|


### PR DESCRIPTION
Use pessimistic operator with the apache2 cookbook dependency instead of greater than equal to, since the new version(v2.0.0) of apache2 cookbook no longer creates specific conf.d directories
