### PR TITLE
Build passenger module only if it does not exist

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -50,5 +50,5 @@ end
 execute "passenger_module" do
   command "#{node['passenger']['ruby_bin']} #{node['passenger']['root_path']}/bin/passenger-install-apache2-module _#{node['passenger']['version']}_ --auto"
   creates node['passenger']['module_path']
-  only_if { node['passenger']['install_module'] }
+  only_if { node['passenger']['install_module'] && !::File.exists?(node['passenger']['module_path']) }
 end


### PR DESCRIPTION
It seems like the combination of `creates` and `only_if` do not play well
together. The passenger module gets recompiled on each run. It seems that
`only_if` overrules `creates` (verified on Chef 11.16.0).

Fixes #34
