### PR TITLE
Fixes #34, closes #37

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -49,6 +49,8 @@ end
 
 execute "passenger_module" do
   command "#{node['passenger']['ruby_bin']} #{node['passenger']['root_path']}/bin/passenger-install-apache2-module _#{node['passenger']['version']}_ --auto"
-  creates node['passenger']['module_path']
   only_if { node['passenger']['install_module'] }
+  # this is late eval'd when Chef converges this resource, and the
+  # attribute may have been modified by the `mod_rails` recipe.
+  not_if { ::File.exist?(node['passenger']['module_path']) }
 end


### PR DESCRIPTION
The `creates` attribute would get an incorrect value for the
`module_path` attribute to check its existence. The magic that is done in the
helper method sets the attribute to a different value - the actual installed
module location - in the `mod_rails` recipe.

This change removes the `creates` attribute and uses the later-evaluated value
of `module_path` to check its existence. This is implemented as a separate
`not_if` than the `only_if` to make it easier to read (and have a specific
comment about).
