### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -16,75 +16,75 @@ verifier:
   sudo: false
 
 platforms:
-- name: debian-8
-  driver:
-    image: debian:8
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+  - name: debian-8
+    driver:
+      image: debian:8
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
-- name: centos-6
-  driver:
-    image: centos:6
-    platform: rhel
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN yum -y install lsof which initscripts net-tools wget net-tools
+  - name: centos-6
+    driver:
+      image: centos:6
+      platform: rhel
+      pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN yum -y install lsof which initscripts net-tools wget net-tools
 
-- name: centos-7
-  driver:
-    image: centos:7
-    platform: rhel
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN yum -y install lsof which systemd-sysv initscripts wget net-tools
+  - name: centos-7
+    driver:
+      image: centos:7
+      platform: rhel
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN yum -y install lsof which systemd-sysv initscripts wget net-tools
 
-- name: fedora-latest
-  driver:
-    image: fedora:latest
-    pid_one_command: /usr/lib/systemd/systemd
-    intermediate_instructions:
-      - RUN dnf -y install which systemd-sysv initscripts wget net-tools
+  - name: fedora-latest
+    driver:
+      image: fedora:latest
+      pid_one_command: /usr/lib/systemd/systemd
+      intermediate_instructions:
+        - RUN dnf -y install which systemd-sysv initscripts wget net-tools
 
-- name: ubuntu-14.04
-  driver:
-    image: ubuntu-upstart:14.04
-    pid_one_command: /sbin/init
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+  - name: ubuntu-14.04
+    driver:
+      image: ubuntu-upstart:14.04
+      pid_one_command: /sbin/init
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
-- name: ubuntu-16.04
-  driver:
-    image: ubuntu:16.04
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN /usr/bin/apt-get update
-      - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
+  - name: ubuntu-16.04
+    driver:
+      image: ubuntu:16.04
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN /usr/bin/apt-get update
+        - RUN /usr/bin/apt-get install apt-transport-https lsb-release procps net-tools -y
 
-- name: opensuse-leap
-  driver:
-    image: opensuse:leap
-    pid_one_command: /bin/systemd
-    intermediate_instructions:
-      - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools
+  - name: opensuse-leap
+    driver:
+      image: opensuse:leap
+      pid_one_command: /bin/systemd
+      intermediate_instructions:
+        - RUN zypper --non-interactive install aaa_base perl-Getopt-Long-Descriptive which net-tools
 suites:
-- name: source
-  run_list:
-  - recipe[passenger_apache2]
+  - name: source
+    run_list:
+      - recipe[passenger_apache2]
 
-- name: package
-  run_list:
-  - recipe[passenger_apache2_test::package]
-  - recipe[passenger_apache2]
-  excludes: ["centos-6", "centos-7", "fedora-latest"]
+  - name: package
+    run_list:
+      - recipe[passenger_apache2_test::package]
+      - recipe[passenger_apache2]
+    excludes: ["centos-6", "centos-7", "fedora-latest"]
 
-- name: version-override
-  run_list:
-  - recipe[passenger_apache2]
-  excludes: ["centos-6", "centos-7", "fedora-latest"]
-  attributes:
-    passenger:
-      version: "4.0.5"
-      module_path: "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/passenger-4.0.5/libout/apache2/mod_passenger.so"
+  - name: version-override
+    run_list:
+      - recipe[passenger_apache2]
+    excludes: ["centos-6", "centos-7", "fedora-latest"]
+    attributes:
+      passenger:
+        version: "4.0.5"
+        module_path: "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/passenger-4.0.5/libout/apache2/mod_passenger.so"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,6 +3,7 @@ driver:
 
 provisioner:
   name: chef_zero
+  policyfile_path: Policyfile.rb
   deprecations_as_errors: true
 
 platforms:
@@ -21,21 +22,27 @@ platforms:
     run_list: apt::default
 
 suites:
-- name: source
-  run_list:
-  - recipe[passenger_apache2]
+  - name: source
+    provisioner:
+      named_run_list: source
+    run_list:
+      - recipe[passenger_apache2]
 
-- name: package
-  run_list:
-  - recipe[passenger_apache2_test::package]
-  - recipe[passenger_apache2]
-  excludes: ["centos-6", "centos-7", "fedora-28"]
+  - name: package
+    provisioner:
+      named_run_list: package
+    run_list:
+      - recipe[passenger_apache2_test::package]
+      - recipe[passenger_apache2]
+    excludes: ["centos-6", "centos-7", "fedora-28"]
 
-- name: version-override
-  run_list:
-  - recipe[passenger_apache2]
-  excludes: ["centos-6", "centos-7", "fedora-28"]
-  attributes:
-    passenger:
-      version: "4.0.5"
-      module_path: "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/passenger-4.0.5/libout/apache2/mod_passenger.so"
+  - name: version-override
+    provisioner:
+      named_run_list: version_override
+    run_list:
+      - recipe[passenger_apache2]
+    excludes: ["centos-6", "centos-7", "fedora-28"]
+    attributes:
+      passenger:
+        version: "4.0.5"
+        module_path: "/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/passenger-4.0.5/libout/apache2/mod_passenger.so"

--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'apt'
-  cookbook 'passenger_apache2_test', path: './test/cookbooks/passenger_apache2_test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+name 'passenger_apache2'
+
+run_list 'passenger_apache2::default'
+
+named_run_list :source, 'passenger_apache2::default'
+named_run_list :package, 'passenger_apache2_test::package', 'passenger_apache2::default'
+named_run_list :version_override, 'passenger_apache2::default'
+
+cookbook 'passenger_apache2', path: '.'
+cookbook 'apache2', git: 'https://github.com/sous-chefs/apache2.git', branch: 'main'
+cookbook 'apt', git: 'https://github.com/sous-chefs/apt.git', branch: 'main'
+cookbook 'passenger_apache2_test', path: './test/cookbooks/passenger_apache2_test'
+cookbook 'yum-epel', git: 'https://github.com/sous-chefs/yum-epel.git', branch: 'main'
+
+Dir.children('./test/cookbooks/passenger_apache2_test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list :"test_#{recipe_name}", "passenger_apache2_test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,7 +36,7 @@ when 'source'
   include_recipe 'passenger_apache2::source'
 when 'package'
   include_recipe 'passenger_apache2::package'
-  node.normal['passenger']['manage_module_conf'] = false
+  node.default['passenger']['manage_module_conf'] = false
 else
   raise "Unsupported passenger installation method requested: #{node['passenger']['install_method']}. Supported: source or package."
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT

--- a/test/cookbooks/passenger_apache2_test/README.md
+++ b/test/cookbooks/passenger_apache2_test/README.md
@@ -1,1 +1,3 @@
+# passenger_apache2_test
+
 This cookbook is used with test-kitchen to test the parent, passenger_apache2 cookbook.

--- a/test/cookbooks/passenger_apache2_test/recipes/package.rb
+++ b/test/cookbooks/passenger_apache2_test/recipes/package.rb
@@ -17,14 +17,14 @@
 # limitations under the License.
 #
 
-node.normal['passenger']['install_method'] = 'package'
-node.normal['passenger']['package'].delete('version')
+node.default['passenger']['install_method'] = 'package'
+node.default['passenger']['package'].delete('version')
 
-node.normal['passenger']['package']['name'] = case node['platform_family']
-                                              when 'debian'
-                                                'libapache2-mod-passenger'
-                                              when 'rhel'
-                                                'mod_passenger'
-                                              end
+node.default['passenger']['package']['name'] = case node['platform_family']
+                                               when 'debian'
+                                                 'libapache2-mod-passenger'
+                                               when 'rhel'
+                                                 'mod_passenger'
+                                               end
 
 include_recipe 'passenger_apache2::default'


### PR DESCRIPTION
## Summary
- replace Berkshelf dependency resolution with Policyfile
- wire ChefSpec and Test Kitchen to Policyfile, including named run lists for existing suites
- remove stale Berksfile references and fix lint issues surfaced by validation

## Validation
- chef install Policyfile.rb
- chef update Policyfile.rb
- cookstyle
- chef exec rspec --format documentation hit a local signed-gem issue; validated with embedded workaround: env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation
- yamllint .
- markdownlint-cli2 "**/*.md"
- actionlint
- git diff --check
- kitchen list
- kitchen diagnose package-ubuntu-2204
- kitchen test package-ubuntu-2204 --destroy=always

Note: attempted source-ubuntu-2204 first; it used Policyfile but failed in the legacy Passenger 4.0.60 source build because its 2008 config.guess cannot identify aarch64. The package suite passed.